### PR TITLE
imeureka / 4주차 / 2문제

### DIFF
--- a/imeureka/graph/가장먼노드.js
+++ b/imeureka/graph/가장먼노드.js
@@ -1,0 +1,64 @@
+function solution(n, edge) {
+	let adjList = new Map();
+
+	// 인접리스트에 추가(양방향)
+	for (let e of edge) {
+		if (!adjList.has(e[0])) {
+			adjList.set(e[0], [e[1]]);
+		} else {
+			adjList.get(e[0]).push(e[1]);
+		}
+
+		if (!adjList.has(e[1])) {
+			adjList.set(e[1], [e[0]]);
+		} else {
+			adjList.get(e[1]).push(e[0]);
+		}
+	}
+
+	// 다익스트라로 최단거리 찾기
+	function dijkstra(n, adjList) {
+		const inf = 200000;
+		// 0번부터 하면 헷갈려서 +1씩 (1번 노드부터 시작)
+		let distance = Array(n + 1).fill(inf);
+		let visited = Array(n + 1).fill(false);
+
+		// 0번은 안쓰고 1번은 자신이므로 0으로
+		distance[0] = 0;
+		distance[1] = 0;
+
+		while (true) {
+			// 방문하지 않은 노드 중에서 최소 거리를 가진 노드를 선택
+			let minDistance = inf;
+			let minNode = -1;
+
+			for (let node = 1; node <= n; node++) {
+				if (!visited[node] && distance[node] < minDistance) {
+					minDistance = distance[node];
+					minNode = node;
+				}
+			}
+			if (minNode === -1) {
+				break;
+			}
+
+			visited[minNode] = true;
+
+			// 이웃 노드까지의 거리가 현재 노드를 거쳐서 가는 거리보다 작으면 업데이트
+			let neighbors = adjList.get(minNode) || [];
+			for (let neighbor of neighbors) {
+				if (!visited[neighbor] && distance[minNode] + 1 < distance[neighbor]) {
+					distance[neighbor] = distance[minNode] + 1;
+				}
+			}
+		}
+
+		return distance;
+	}
+
+	const distances = dijkstra(n, adjList);
+	const maxValue = Math.max(...distances);
+	const maxCount = distances.filter((value) => value === maxValue).length;
+
+	return maxCount;
+}

--- a/imeureka/heap/이중우선순위큐.js
+++ b/imeureka/heap/이중우선순위큐.js
@@ -1,0 +1,22 @@
+function solution(operations) {
+	let answer = [];
+
+	operations.forEach(function (e) {
+		let num = 0;
+		if (e.startsWith("I")) {
+			answer.push(parseInt(e.split(" ")[1]));
+		} else if (e.startsWith("D -")) {
+			num = Math.min(...answer);
+			console.log(num);
+			answer.splice(answer.indexOf(num), 1);
+		} else {
+			num = Math.max(...answer);
+			answer.splice(answer.indexOf(num), 1);
+		}
+	});
+
+	if (answer.length === 0) {
+		return [0, 0];
+	}
+	return [Math.max(...answer), Math.min(...answer)];
+}


### PR DESCRIPTION
## 1️⃣ 이중우선순위큐
> heap / Level 3
### 문제접근
단순 배열로 풀면 되는 문제
시간 복잡도 O(N)
heap → 사용하면 O(logN)가능 하긴 한데 js에선 우선순위큐를 직접 구현해야 한다 그래서 [더 맵게]문제도 js로 접근할 땐 난이도 높은 문제라 한다. 

## 2️⃣ 가장 먼 노드
> graph / Level 3

### 문제접근
접리스트 + 다익스트라 알고리즘 사용
시간복잡도 O(n^2)
1. 인접리스트로 변환
     → [출발노드: [갈 수 있는 노드들]]
    1: [3, 2], 2: [3, 1, 4, 5]….  
2. 다익스트라 알고리즘으로 1번노드부터 각 노드까지의 최단거리 리스트 구하기
    → 방문하지 않은 노드 중, 최단 거리 노드를 방문하고.
    그 노드를 통했을때 거리가 갱신될 수 있다면 갱신함
    1 → 4의 최단거리는 1→2→3→4를 통해서 가는 경우가 제일 빠름
3. 그 중 최대값을 구하고, 그 최대값의 개수를 셈